### PR TITLE
Fix request response objects in swagger documentation

### DIFF
--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -223,14 +223,14 @@ func resetPasswordHandler(email string, code string, newPassword string, handler
 	if err := handler.ResetPassword(email, code, newPassword); err != nil {
 		return handleResetPasswordError(err)
 	}
-	return http.StatusNoContent, resetpass.NewResponse()
+	return http.StatusNoContent, resetpass.NewResponse(http.StatusNoContent)
 }
 
 func handleResetPasswordError(err error) (int, resetpass.Response) {
 	if isInvalidEmail(err) || isPasswordLength(err) || isInvalidCode(err) || isSamePasswordChange(err) {
-		return http.StatusBadRequest, resetpass.NewUnsuccessfulResponse()
+		return http.StatusBadRequest, resetpass.NewErrorResponse(http.StatusBadRequest, err)
 	}
-	return http.StatusInternalServerError, resetpass.NewUnsuccessfulResponse()
+	return http.StatusInternalServerError, resetpass.NewErrorResponse(http.StatusInternalServerError, err)
 }
 
 func isInvalidCode(err error) bool {

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -90,7 +90,7 @@ func handleLoginError(err error) (int, login.RestResponse) {
 // @Accept  json
 // @Produce  json
 // @Param signup body signup.Request true "Signup Request"
-// @Success 201 {object} signup.SwaggerResponse
+// @Success 201 {object} signup.Response
 // @Failure 400 {object} rest.ResponseWrapper
 // @Failure 500 {object} rest.ResponseWrapper
 // @Router /user/signup [post]
@@ -113,7 +113,7 @@ func signupHandler(request signup.Request, handler interactors.Authenticator) (i
 	if err != nil {
 		return handleSignUpError(err)
 	}
-	return http.StatusCreated, signup.NewResponse(http.StatusCreated, &signup.Result{Success: true})
+	return http.StatusCreated, signup.NewResponse(http.StatusCreated)
 }
 
 func handleSignUpError(err error) (int, signup.Response) {

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -43,7 +43,7 @@ func configureAuthRoutes(restConfig authenticatorRESTConfigurator, r *gin.Engine
 // @Accept  json
 // @Produce  json
 // @Param login body login.Request true "Login Request"
-// @Success 200 {object} login.SwaggerResponse
+// @Success 200 {object} login.RestResponse
 // @Failure 400 {object} rest.ResponseWrapper
 // @Failure 401 {object} rest.ResponseWrapper
 // @Failure 500 {object} rest.ResponseWrapper
@@ -62,7 +62,7 @@ func isInvalidLoginRequest(c *gin.Context, request *login.Request) bool {
 	return c.ShouldBindJSON(request) != nil || request.Email == "" || request.Password == ""
 }
 
-func loginHandler(email, password string, handler interactors.Authenticator) (int, login.Response) {
+func loginHandler(email, password string, handler interactors.Authenticator) (int, login.RestResponse) {
 	response, err := handler.Login(email, password)
 	if err != nil {
 		return handleLoginError(err)
@@ -70,7 +70,7 @@ func loginHandler(email, password string, handler interactors.Authenticator) (in
 	return http.StatusOK, login.NewResponse(http.StatusOK, mappers.LoginResponseToResult(*response))
 }
 
-func handleLoginError(err error) (int, login.Response) {
+func handleLoginError(err error) (int, login.RestResponse) {
 	var code int
 	switch err.(type) {
 	case util.InvalidEmailError:

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -281,7 +281,7 @@ func handleForgotPasswordError(err error) (int, forgotpass.Response) {
 // @Accept  json
 // @Produce  json
 // @Param Authorization header string true "Authorization: Bearer <jwtToken>"
-// @Success 200 {object} token.SwaggerResponse
+// @Success 200 {object} token.Response
 // @Failure 400 {object} rest.ResponseWrapper
 // @Failure 401 {object} rest.ResponseWrapper
 // @Failure 500 {object} rest.ResponseWrapper
@@ -317,7 +317,7 @@ func verifyJWTHandler(t string, handler interactors.Authenticator) (int, token.R
 		}
 		return http.StatusInternalServerError, token.NewErrorResponse(http.StatusInternalServerError, err)
 	}
-	return http.StatusOK, token.NewResponse(http.StatusOK, &token.Result{User: user})
+	return http.StatusOK, token.NewResponse(http.StatusOK, user)
 }
 
 func isInvalidToken(err error) bool {

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -143,7 +143,7 @@ func isDuplicatedEmail(err error) bool {
 // @Accept  json
 // @Produce  json
 // @Param changePassword body changepass.Request true "Change password Request"
-// @Success 200 {object} changepass.SwaggerResponse
+// @Success 200 {object} changepass.Response
 // @Failure 400 {object} rest.ResponseWrapper
 // @Failure 401 {object} rest.ResponseWrapper
 // @Failure 500 {object} rest.ResponseWrapper

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -243,7 +243,7 @@ func isInvalidCode(err error) bool {
 // @Accept  json
 // @Produce  json
 // @Param resetPassword body forgotpass.Request true "Forgot password request"
-// @Success 202 {object} forgotpass.SwaggerResponse
+// @Success 202 {object} forgotpass.Response
 // @Failure 400 {object} rest.ResponseWrapper
 // @Failure 500 {object} rest.ResponseWrapper
 // @Router /user/reset-password-request [put]
@@ -266,7 +266,7 @@ func forgotPasswordHandler(email string, handler interactors.PasswordManager) (i
 	if err != nil {
 		return handleForgotPasswordError(err)
 	}
-	return http.StatusAccepted, forgotpass.NewResponse(http.StatusAccepted, &forgotpass.Result{Success: true})
+	return http.StatusAccepted, forgotpass.NewResponse(http.StatusAccepted)
 }
 
 func handleForgotPasswordError(err error) (int, forgotpass.Response) {

--- a/api/authentication/structures/changepass/change_password.go
+++ b/api/authentication/structures/changepass/change_password.go
@@ -4,10 +4,10 @@ import "github.com/bixlabs/authentication/tools/rest"
 
 type Response struct {
 	rest.ResponseWrapper
-	Result *Result `json:"result"`
+	Result Result `json:"result,omitempty"`
 }
 
-func newResponse(code int, result *Result, err error) Response {
+func newResponse(code int, result Result, err error) Response {
 	r := Response{}
 	r.ResponseWrapper = rest.NewResponseWrapper(code, err)
 	r.Result = result
@@ -15,11 +15,11 @@ func newResponse(code int, result *Result, err error) Response {
 }
 
 func NewErrorResponse(code int, err error) Response {
-	return newResponse(code, nil, err)
+	return newResponse(code, Result{}, err)
 }
 
 func NewResponse(code int, success bool) Response {
-	return newResponse(code, &Result{Success: success}, nil)
+	return newResponse(code, Result{Success: success}, nil)
 }
 
 type Result struct {

--- a/api/authentication/structures/changepass/change_password.go
+++ b/api/authentication/structures/changepass/change_password.go
@@ -2,9 +2,8 @@ package changepass
 
 import "github.com/bixlabs/authentication/tools/rest"
 
-type Response struct {
-	rest.ResponseWrapper
-	Result Result `json:"result,omitempty"`
+func NewResponse(code int, success bool) Response {
+	return newResponse(code, Result{Success: success}, nil)
 }
 
 func newResponse(code int, result Result, err error) Response {
@@ -18,8 +17,9 @@ func NewErrorResponse(code int, err error) Response {
 	return newResponse(code, Result{}, err)
 }
 
-func NewResponse(code int, success bool) Response {
-	return newResponse(code, Result{Success: success}, nil)
+type Response struct {
+	rest.ResponseWrapper
+	Result Result `json:"result,omitempty"`
 }
 
 type Result struct {
@@ -30,13 +30,4 @@ type Request struct {
 	OldPassword string `json:"oldPassword"`
 	NewPassword string `json:"newPassword"`
 	Email       string `json:"email"`
-}
-
-// We need this because go-swag library doesn't support embedded struct and doesn't show all the attributes in
-// the documentation.
-type SwaggerResponse struct {
-	Status   string    `json:"status"`
-	Code     int       `json:"code"`
-	Messages []string  `json:"messages"`
-	Result   *Response `json:"result,omitempty"`
 }

--- a/api/authentication/structures/forgotpass/reset_password_request.go
+++ b/api/authentication/structures/forgotpass/reset_password_request.go
@@ -4,9 +4,8 @@ import (
 	"github.com/bixlabs/authentication/tools/rest"
 )
 
-type Response struct {
-	rest.ResponseWrapper
-	Result Result `json:"result,omitempty"`
+func NewResponse(code int) Response {
+	return newResponse(code, Result{Success: true}, nil)
 }
 
 func newResponse(code int, result Result, err error) Response {
@@ -20,8 +19,9 @@ func NewErrorResponse(code int, err error) Response {
 	return newResponse(code, Result{}, err)
 }
 
-func NewResponse(code int) Response {
-	return newResponse(code, Result{Success: true}, nil)
+type Response struct {
+	rest.ResponseWrapper
+	Result Result `json:"result,omitempty"`
 }
 
 type Result struct {

--- a/api/authentication/structures/forgotpass/reset_password_request.go
+++ b/api/authentication/structures/forgotpass/reset_password_request.go
@@ -6,10 +6,10 @@ import (
 
 type Response struct {
 	rest.ResponseWrapper
-	Result *Result `json:"result,omitempty"`
+	Result Result `json:"result,omitempty"`
 }
 
-func newResponse(code int, result *Result, err error) Response {
+func newResponse(code int, result Result, err error) Response {
 	r := Response{}
 	r.ResponseWrapper = rest.NewResponseWrapper(code, err)
 	r.Result = result
@@ -17,11 +17,11 @@ func newResponse(code int, result *Result, err error) Response {
 }
 
 func NewErrorResponse(code int, err error) Response {
-	return newResponse(code, nil, err)
+	return newResponse(code, Result{}, err)
 }
 
-func NewResponse(code int, result *Result) Response {
-	return newResponse(code, result, nil)
+func NewResponse(code int) Response {
+	return newResponse(code, Result{Success: true}, nil)
 }
 
 type Result struct {
@@ -30,13 +30,4 @@ type Result struct {
 
 type Request struct {
 	Email string `json:"email"`
-}
-
-// We need this because go-swag library doesn't support embedded struct and doesn't show all the attributes in
-// the documentation.
-type SwaggerResponse struct {
-	Status   string   `json:"status"`
-	Code     int      `json:"code"`
-	Messages []string `json:"messages"`
-	Result   *Result  `json:"result,omitempty"`
 }

--- a/api/authentication/structures/login/login.go
+++ b/api/authentication/structures/login/login.go
@@ -5,9 +5,8 @@ import (
 	"github.com/bixlabs/authentication/tools/rest"
 )
 
-type RestResponse struct {
-	rest.ResponseWrapper
-	Result Result `json:"result,omitempty"`
+func NewResponse(code int, result Result) RestResponse {
+	return newResponse(code, result, nil)
 }
 
 func newResponse(code int, result Result, err error) RestResponse {
@@ -21,8 +20,9 @@ func NewErrorResponse(code int, err error) RestResponse {
 	return newResponse(code, Result{}, err)
 }
 
-func NewResponse(code int, result Result) RestResponse {
-	return newResponse(code, result, nil)
+type RestResponse struct {
+	rest.ResponseWrapper
+	Result Result `json:"result,omitempty"`
 }
 
 type Result struct {
@@ -32,13 +32,4 @@ type Result struct {
 type Request struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
-}
-
-// We need this because go-swag library doesn't support embedded struct and doesn't show all the attributes in
-// the documentation.
-type SwaggerResponse struct {
-	Status   string          `json:"status"`
-	Code     int             `json:"code"`
-	Messages []string        `json:"messages"`
-	Result   *login.Response `json:"result,omitempty"`
 }

--- a/api/authentication/structures/login/login.go
+++ b/api/authentication/structures/login/login.go
@@ -5,23 +5,23 @@ import (
 	"github.com/bixlabs/authentication/tools/rest"
 )
 
-type Response struct {
+type RestResponse struct {
 	rest.ResponseWrapper
-	Result *Result `json:"result,omitempty"`
+	Result Result `json:"result,omitempty"`
 }
 
-func newResponse(code int, result *Result, err error) Response {
-	r := Response{}
+func newResponse(code int, result Result, err error) RestResponse {
+	r := RestResponse{}
 	r.ResponseWrapper = rest.NewResponseWrapper(code, err)
 	r.Result = result
 	return r
 }
 
-func NewErrorResponse(code int, err error) Response {
-	return newResponse(code, nil, err)
+func NewErrorResponse(code int, err error) RestResponse {
+	return newResponse(code, Result{}, err)
 }
 
-func NewResponse(code int, result *Result) Response {
+func NewResponse(code int, result Result) RestResponse {
 	return newResponse(code, result, nil)
 }
 

--- a/api/authentication/structures/mappers/mappers.go
+++ b/api/authentication/structures/mappers/mappers.go
@@ -12,8 +12,8 @@ func ChangePasswordRequestToUser(request changepass.Request) structures.User {
 	return structures.User{Email: request.Email, Password: request.OldPassword}
 }
 
-func LoginResponseToResult(r login.Response) *api.Result {
-	return &api.Result{Response: r}
+func LoginResponseToResult(r login.Response) api.Result {
+	return api.Result{Response: r}
 }
 
 func SignupRequestToUser(request signup.Request) structures.User {

--- a/api/authentication/structures/resetpass/reset_password.go
+++ b/api/authentication/structures/resetpass/reset_password.go
@@ -2,9 +2,8 @@ package resetpass
 
 import "github.com/bixlabs/authentication/tools/rest"
 
-type Response struct {
-	rest.ResponseWrapper
-	Result Result `json:"result,omitempty"`
+func NewResponse(code int) Response {
+	return newResponse(code, Result{Success: true}, nil)
 }
 
 func newResponse(code int, result Result, err error) Response {
@@ -14,12 +13,13 @@ func newResponse(code int, result Result, err error) Response {
 	return r
 }
 
-func NewResponse(code int) Response {
-	return newResponse(code, Result{Success:true}, nil)
+func NewErrorResponse(code int, err error) Response {
+	return newResponse(code, Result{Success: false}, err)
 }
 
-func NewErrorResponse(code int, err error) Response {
-	return newResponse(code, Result{Success:false}, err)
+type Response struct {
+	rest.ResponseWrapper
+	Result Result `json:"result,omitempty"`
 }
 
 type Result struct {

--- a/api/authentication/structures/resetpass/reset_password.go
+++ b/api/authentication/structures/resetpass/reset_password.go
@@ -7,12 +7,19 @@ type Response struct {
 	Result Result `json:"result,omitempty"`
 }
 
-func NewResponse() Response {
-	return Response{Result: Result{Success: true}}
+func newResponse(code int, result Result, err error) Response {
+	r := Response{}
+	r.ResponseWrapper = rest.NewResponseWrapper(code, err)
+	r.Result = result
+	return r
 }
 
-func NewUnsuccessfulResponse() Response {
-	return Response{Result: Result{Success: false}}
+func NewResponse(code int) Response {
+	return newResponse(code, Result{Success:true}, nil)
+}
+
+func NewErrorResponse(code int, err error) Response {
+	return newResponse(code, Result{Success:false}, err)
 }
 
 type Result struct {

--- a/api/authentication/structures/resetpass/reset_password.go
+++ b/api/authentication/structures/resetpass/reset_password.go
@@ -1,12 +1,18 @@
-package passreset
+package resetpass
 
-//TODO: We could use nested struct promoted fields here but the swaggo
-// library is not generating correct documentation using that.
+import "github.com/bixlabs/authentication/tools/rest"
+
 type Response struct {
-	Status   string   `json:"status"`
-	Code     int      `json:"code"`
-	Messages []string `json:"messages"`
-	Result   Result   `json:"result"`
+	rest.ResponseWrapper
+	Result Result `json:"result,omitempty"`
+}
+
+func NewResponse() Response {
+	return Response{Result: Result{Success: true}}
+}
+
+func NewUnsuccessfulResponse() Response {
+	return Response{Result: Result{Success: false}}
 }
 
 type Result struct {

--- a/api/authentication/structures/signup/signup.go
+++ b/api/authentication/structures/signup/signup.go
@@ -2,9 +2,8 @@ package signup
 
 import "github.com/bixlabs/authentication/tools/rest"
 
-type Response struct {
-	rest.ResponseWrapper
-	Result Result `json:"result"`
+func NewResponse(code int) Response {
+	return newResponse(code, Result{Success: true}, nil)
 }
 
 func newResponse(code int, result Result, err error) Response {
@@ -18,8 +17,9 @@ func NewErrorResponse(code int, err error) Response {
 	return newResponse(code, Result{}, err)
 }
 
-func NewResponse(code int) Response {
-	return newResponse(code, Result{Success: true}, nil)
+type Response struct {
+	rest.ResponseWrapper
+	Result Result `json:"result"`
 }
 
 type Result struct {

--- a/api/authentication/structures/signup/signup.go
+++ b/api/authentication/structures/signup/signup.go
@@ -2,14 +2,12 @@ package signup
 
 import "github.com/bixlabs/authentication/tools/rest"
 
-//TODO: We could use nested struct promoted fields here but swaggo
-// library is not generating correct documentation using that.
 type Response struct {
 	rest.ResponseWrapper
-	Result *Result `json:"result"`
+	Result Result `json:"result"`
 }
 
-func newResponse(code int, result *Result, err error) Response {
+func newResponse(code int, result Result, err error) Response {
 	r := Response{}
 	r.ResponseWrapper = rest.NewResponseWrapper(code, err)
 	r.Result = result
@@ -17,11 +15,11 @@ func newResponse(code int, result *Result, err error) Response {
 }
 
 func NewErrorResponse(code int, err error) Response {
-	return newResponse(code, nil, err)
+	return newResponse(code, Result{}, err)
 }
 
-func NewResponse(code int, result *Result) Response {
-	return newResponse(code, result, nil)
+func NewResponse(code int) Response {
+	return newResponse(code, Result{Success: true}, nil)
 }
 
 type Result struct {
@@ -35,13 +33,4 @@ type Request struct {
 	SecondName       string `json:"secondName,omitempty"`
 	FamilyName       string `json:"familyName,omitempty"`
 	SecondFamilyName string `json:"secondFamilyName,omitempty"`
-}
-
-// We need this because go-swag library doesn't support embedded struct and doesn't show all the attributes in
-// the documentation.
-type SwaggerResponse struct {
-	Status   string    `json:"status"`
-	Code     int       `json:"code"`
-	Messages []string  `json:"messages"`
-	Result   *Response `json:"result,omitempty"`
 }

--- a/api/authentication/structures/token/token.go
+++ b/api/authentication/structures/token/token.go
@@ -5,14 +5,12 @@ import (
 	"github.com/bixlabs/authentication/tools/rest"
 )
 
-//TODO: We could use nested struct promoted fields here but swaggo
-// library is not generating correct documentation using that.
 type Response struct {
 	rest.ResponseWrapper
-	Result *Result `json:"result"`
+	Result Result `json:"result"`
 }
 
-func newResponse(code int, result *Result, err error) Response {
+func newResponse(code int, result Result, err error) Response {
 	r := Response{}
 	r.ResponseWrapper = rest.NewResponseWrapper(code, err)
 	r.Result = result
@@ -20,22 +18,13 @@ func newResponse(code int, result *Result, err error) Response {
 }
 
 func NewErrorResponse(code int, err error) Response {
-	return newResponse(code, nil, err)
+	return newResponse(code, Result{}, err)
 }
 
-func NewResponse(code int, result *Result) Response {
-	return newResponse(code, result, nil)
+func NewResponse(code int, user structures.User) Response {
+	return newResponse(code, Result{User: user}, nil)
 }
 
 type Result struct {
 	User structures.User `json:"user"`
-}
-
-// We need this because go-swag library doesn't support embedded struct and doesn't show all the attributes in
-// the documentation.
-type SwaggerResponse struct {
-	Status   string    `json:"status"`
-	Code     int       `json:"code"`
-	Messages []string  `json:"messages"`
-	Result   *Response `json:"result,omitempty"`
 }

--- a/api/authentication/structures/token/token.go
+++ b/api/authentication/structures/token/token.go
@@ -5,9 +5,8 @@ import (
 	"github.com/bixlabs/authentication/tools/rest"
 )
 
-type Response struct {
-	rest.ResponseWrapper
-	Result Result `json:"result"`
+func NewResponse(code int, user structures.User) Response {
+	return newResponse(code, Result{User: user}, nil)
 }
 
 func newResponse(code int, result Result, err error) Response {
@@ -21,8 +20,9 @@ func NewErrorResponse(code int, err error) Response {
 	return newResponse(code, Result{}, err)
 }
 
-func NewResponse(code int, user structures.User) Response {
-	return newResponse(code, Result{User: user}, nil)
+type Response struct {
+	rest.ResponseWrapper
+	Result Result `json:"result"`
 }
 
 type Result struct {

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWX
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -104,6 +105,7 @@ github.com/go-openapi/spec v0.19.2 h1:SStNd1jRcYtfKCN7R0laGNs80WYYvn5CbBjM2sOmCr
 github.com/go-openapi/spec v0.19.2/go.mod h1:sCxk3jxKgioEJikev4fgkNmwS+3kuYdJtcsZsD5zxMY=
 github.com/go-openapi/spec v0.19.4 h1:ixzUSnHTd6hCemgtAJgluaTSGYpLNpJY4mA2DIkdOAo=
 github.com/go-openapi/spec v0.19.4/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
+github.com/go-openapi/spec v0.19.7 h1:0xWSeMd35y5avQAThZR2PkEuqSosoS5t6gDH4L8n11M=
 github.com/go-openapi/spec v0.19.7/go.mod h1:Hm2Jr4jv8G1ciIAo+frC/Ft+rR2kQDh8JHKHb3gWUSk=
 github.com/go-openapi/swag v0.17.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
@@ -111,6 +113,7 @@ github.com/go-openapi/swag v0.19.4 h1:i/65mCM9s1h8eCkT07F5Z/C1e/f8VTgEwer+00yevp
 github.com/go-openapi/swag v0.19.4/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-openapi/swag v0.19.8 h1:vfK6jLhs7OI4tAXkvkooviaE1JEPcw3mutyegLHHjmk=
 github.com/go-openapi/swag v0.19.8/go.mod h1:ao+8BpOPyKdpQz3AOJfbeEVpLmWAvlT1IfTe5McPyhY=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.12.1 h1:2FITxuFt/xuCNP1Acdhv62OzaCiviiE4kotfhkmOqEc=
@@ -234,6 +237,7 @@ github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e h1:hB2xlXdHp/pmPZq0y3QnmWAArdw9PqbmotexnWx/FU8=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8=
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -454,6 +458,7 @@ golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 h1:k7pJ2yAPLPgbskkFdhRCsA77k2fySZ1zf2zCjvQCiIM=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -492,6 +497,7 @@ golang.org/x/sys v0.0.0-20190902133755-9109b7679e13 h1:tdsQdquKbTNMsSZLqnLELJGzC
 golang.org/x/sys v0.0.0-20190902133755-9109b7679e13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -522,10 +528,12 @@ golang.org/x/tools v0.0.0-20190812191214-4147ede4f82b/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20190903025054-afe7f8212f0d h1:JfNSEO6oQZymcWt5etSfS4uexs5YCO+WH/jmrs/hXk4=
 golang.org/x/tools v0.0.0-20190903025054-afe7f8212f0d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200325203130-f53864d0dba1 h1:odiryKYJy7CjdrZxhrcE1Z8L9+kGyGZOnfpuauvdCeU=
 golang.org/x/tools v0.0.0-20200325203130-f53864d0dba1/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=


### PR DESCRIPTION
## Description 
Swagger documentation fixes.


## List of changes 
* Swagger documenation was not rendering some response objects correctly because of an old bug in Swaggo and then because of a bug in our code.

## Steps to Test or Reproduce
Just check swagger documenation now, you won't see empty `{}` anymore.

## Impacted Areas in Application 
List general components of the application that this PR will affect.
* REST documentation

## Migrations
NO
