### PR TITLE
AM-34 Parse JWT from header using gin native method on API rest layer

### DIFF
--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -302,15 +302,22 @@ func (config authenticatorRESTConfigurator) verifyJWT(c *gin.Context) {
 }
 
 func getTokenFromHeader(c *gin.Context) (string, error) {
-	t := c.Request.Header.Get("Authorization")
+	type authHeader struct {
+		authorization string `header:"Authorization"`
+	}
 
-	if t == "" || !strings.Contains(t, "Bearer") {
+	t := authHeader{}
+
+	if err := c.ShouldBindHeader(&t); err != nil {
 		return "", errors.New("token missing or malformed")
 	}
-	headerSeparated := strings.Split(t, " ")
-	if len(headerSeparated) != tokenHeaderLength {
+
+	headerSeparated := strings.Split(t.authorization, " ")
+
+	if len(headerSeparated) != tokenHeaderLength || !strings.Contains(t.authorization, "Bearer") {
 		return "", errors.New("token missing or malformed")
 	}
+
 	return headerSeparated[1], nil
 }
 

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -301,11 +301,11 @@ func (config authenticatorRESTConfigurator) verifyJWT(c *gin.Context) {
 	}
 }
 
-func getTokenFromHeader(c *gin.Context) (string, error) {
-	type authHeader struct {
-		authorization string `header:"Authorization"`
-	}
+type authHeader struct {
+	authorization string `header:"Authorization"`
+}
 
+func getTokenFromHeader(c *gin.Context) (string, error) {
 	t := authHeader{}
 
 	if err := c.ShouldBindHeader(&t); err != nil {


### PR DESCRIPTION
## Description 
This pull request changes the parsing method of the JWT of the header in the API rest layer for using a native method instead of parsing manually.

## Stories
[AM-34](https://bixlabs.atlassian.net/secure/RapidBoard.jspa?rapidView=120&projectKey=AM&modal=detail&selectedIssue=AM-34)

## List of changes 
*In the API rest layer the authentication implementation used to parse manually JWT from the header, now it uses native method function from gin-gonic

## Steps to Test or Reproduce
```bash
$ make
$ make run
```
## Impacted Areas in Application 
* Authentication (API rest layer)

## Migrations
NO
