### PR TITLE
Am-34 fix attribute of authHeader JWT parser

### DIFF
--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -302,7 +302,7 @@ func (config authenticatorRESTConfigurator) verifyJWT(c *gin.Context) {
 }
 
 type authHeader struct {
-	authorization string `header:"Authorization"`
+	Authorization string `header:"Authorization"`
 }
 
 func getTokenFromHeader(c *gin.Context) (string, error) {
@@ -312,9 +312,9 @@ func getTokenFromHeader(c *gin.Context) (string, error) {
 		return "", errors.New("token missing or malformed")
 	}
 
-	headerSeparated := strings.Split(t.authorization, " ")
+	headerSeparated := strings.Split(t.Authorization, " ")
 
-	if len(headerSeparated) != tokenHeaderLength || !strings.Contains(t.authorization, "Bearer") {
+	if len(headerSeparated) != tokenHeaderLength || !strings.Contains(t.Authorization, "Bearer") {
 		return "", errors.New("token missing or malformed")
 	}
 

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -302,15 +302,22 @@ func (config authenticatorRESTConfigurator) verifyJWT(c *gin.Context) {
 }
 
 func getTokenFromHeader(c *gin.Context) (string, error) {
-	t := c.Request.Header.Get("Authorization")
+	type authHeader struct {
+		authorization string `header:"Authorization"`
+	}
 
-	if t == "" || !strings.Contains(t, "Bearer") {
+	t := authHeader{}
+
+	if err := c.ShouldBindHeader(&t); err != nil {
 		return "", errors.New("token missing or malformed")
 	}
-	headerSeparated := strings.Split(t, " ")
-	if len(headerSeparated) != tokenHeaderLength {
+
+	headerSeparated := strings.Split(t.authorization, " ")
+
+	if len(headerSeparated) != tokenHeaderLength || !strings.Contains(t.authorization, "Bearer") {
 		return "", errors.New("token missing or malformed")
 	}
+
 	return headerSeparated[1], nil
 }
 

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -301,11 +301,11 @@ func (config authenticatorRESTConfigurator) verifyJWT(c *gin.Context) {
 	}
 }
 
-func getTokenFromHeader(c *gin.Context) (string, error) {
-	type authHeader struct {
-		authorization string `header:"Authorization"`
-	}
+type authHeader struct {
+	authorization string `header:"Authorization"`
+}
 
+func getTokenFromHeader(c *gin.Context) (string, error) {
 	t := authHeader{}
 
 	if err := c.ShouldBindHeader(&t); err != nil {


### PR DESCRIPTION
## Description 
Change the access of an attribute, who was private, and the libraries that needed for parsing it could not access it.

## Stories
AM-34

## List of changes 
Update attribute from private to public (Firs letter lowercase to uppercase)

## Steps to Test or Reproduce
make
make run

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

## Impacted Areas in Application 
*Attribute in authHeader struct over the API rest layer

## Migrations
NO
