### PR TITLE
Am-33 remove shadowing valid function on JWT claims, update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ $ make
 ```
 
 * Through this we install some binaries and all the go libraries that the project needs.
-* We also run the tests and the linter.
 
 ## Go Modules
 * If you need more information about them please go [here](https://github.com/golang/go/wiki/Modules#how-to-define-a-module)

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -302,7 +302,7 @@ func (config authenticatorRESTConfigurator) verifyJWT(c *gin.Context) {
 }
 
 type authHeader struct {
-	authorization string `header:"Authorization"`
+	Authorization string `header:"Authorization"`
 }
 
 func getTokenFromHeader(c *gin.Context) (string, error) {
@@ -312,9 +312,9 @@ func getTokenFromHeader(c *gin.Context) (string, error) {
 		return "", errors.New("token missing or malformed")
 	}
 
-	headerSeparated := strings.Split(t.authorization, " ")
+	headerSeparated := strings.Split(t.Authorization, " ")
 
-	if len(headerSeparated) != tokenHeaderLength || !strings.Contains(t.authorization, "Bearer") {
+	if len(headerSeparated) != tokenHeaderLength || !strings.Contains(t.Authorization, "Bearer") {
 		return "", errors.New("token missing or malformed")
 	}
 

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -302,15 +302,22 @@ func (config authenticatorRESTConfigurator) verifyJWT(c *gin.Context) {
 }
 
 func getTokenFromHeader(c *gin.Context) (string, error) {
-	t := c.Request.Header.Get("Authorization")
+	type authHeader struct {
+		authorization string `header:"Authorization"`
+	}
 
-	if t == "" || !strings.Contains(t, "Bearer") {
+	t := authHeader{}
+
+	if err := c.ShouldBindHeader(&t); err != nil {
 		return "", errors.New("token missing or malformed")
 	}
-	headerSeparated := strings.Split(t, " ")
-	if len(headerSeparated) != tokenHeaderLength {
+
+	headerSeparated := strings.Split(t.authorization, " ")
+
+	if len(headerSeparated) != tokenHeaderLength || !strings.Contains(t.authorization, "Bearer") {
 		return "", errors.New("token missing or malformed")
 	}
+
 	return headerSeparated[1], nil
 }
 

--- a/api/authentication/authentication.go
+++ b/api/authentication/authentication.go
@@ -301,11 +301,11 @@ func (config authenticatorRESTConfigurator) verifyJWT(c *gin.Context) {
 	}
 }
 
-func getTokenFromHeader(c *gin.Context) (string, error) {
-	type authHeader struct {
-		authorization string `header:"Authorization"`
-	}
+type authHeader struct {
+	authorization string `header:"Authorization"`
+}
 
+func getTokenFromHeader(c *gin.Context) (string, error) {
 	t := authHeader{}
 
 	if err := c.ShouldBindHeader(&t); err != nil {

--- a/authenticator/interactors/implementation/authenticator.go
+++ b/authenticator/interactors/implementation/authenticator.go
@@ -106,16 +106,6 @@ type userClaims struct {
 	*jwt.StandardClaims
 }
 
-// TODO: This is a workaround because jwt-go is validating iat when it shouldn't (jwt specification doesn't say so)
-// let's remove this later when jwt-go removes the iat validation in v4.
-// https://github.com/dgrijalva/jwt-go/issues/314#issuecomment-481789374
-func (c *userClaims) Valid() error {
-	c.StandardClaims.IssuedAt /= 10
-	valid := c.StandardClaims.Valid()
-	c.StandardClaims.IssuedAt *= 10
-	return valid
-}
-
 func (auth authenticator) Signup(user structures.User) (structures.User, error) {
 	contextLogger := tools.Log().WithFields(logrus.Fields{"email": user.Email, "meth": "authenticator:Signup"})
 
@@ -188,9 +178,5 @@ func (auth authenticator) validateAndObtainClaims(token jwt.Token) (structures.U
 		return structures.User{}, util.InvalidJWTToken{}
 	}
 
-	if err := claims.Valid(); err != nil {
-		tools.Log().WithError(err).Debug("an error happened while validating the JWT token")
-		return structures.User{}, util.InvalidJWTToken{}
-	}
 	return claims.User, nil
 }


### PR DESCRIPTION
## Description 
*The valid function inside de authenticator was a workaround because de jwt-go library was validating IssuedtAt claims where it was not supposed to, the function was removed due to version update of jwt-go library.
*Since makefile was updated, the readme file had to be updated

## Stories
[AM-33](https://bixlabs.atlassian.net/secure/RapidBoard.jspa?rapidView=120&projectKey=AM&modal=detail&selectedIssue=AM-33)

## List of changes 
*Function valid() in the authenticator was removed (Business layer)
*Readme file $make command update

## Steps to Test or Reproduce
```bash
$make
$make run
```

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

## Impacted Areas in Application 
List the general components of the application that this PR will affect.
* Authenticator.
*Documentation

## Migrations
NO
